### PR TITLE
fix: remove white bars when pinching out on mobile

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -66,7 +66,7 @@
         align-items: center;
         width: 100%;
         height: 100%;
-        background-color: #22211f;
+        background-color: var(--main-background-color);
         font-family: sans-serif;
         padding: 5%;
         gap: 2rem;

--- a/src/style.css
+++ b/src/style.css
@@ -6,10 +6,12 @@ body > div {
     margin: 0;
     padding: 0;
     overflow: hidden;
+    background: var(--main-background-color);
 }
 
 *,
 *::before,
 *::after {
     box-sizing: border-box;
+    --main-background-color: #22211f;
 }


### PR DESCRIPTION
extract a background color for both body and main to use to remove any white bars present on mobile
